### PR TITLE
fix(dependabot): run build after licenses

### DIFF
--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Copyright (C) 2025 Two Factor Authentication Service, Inc.
+# Licensed under the Business Source License 1.1
+# See LICENSE file for full terms
+
 name: Dependabot Post-Update License Headers
 
 on:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,7 @@ on:
 jobs:
 
   build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,4 +55,3 @@ jobs:
         run: |
           go run main.go &
           RUN_E2E_TESTS=true go test ./e2e/... -v -count=1
-          

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,10 @@
 name: Go
 
 on:
+  workflow_run:
+    workflows: [ "Dependabot Post-Update License Headers" ]
+    types:
+      - completed
   push:
     branches: [ "main", "develop" ]
   pull_request:


### PR DESCRIPTION
An attempt to run Go pipeline after license fix for dependabot branches.
