### PR TITLE
fix: dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        ref: ${{ github.event.pull_request.head.ref }}
       - name: Commit and push changes to licenses.json (if any)
         run: |          
           make licenses


### PR DESCRIPTION
Checkout branch rather than commit. This will allow us to push changes
with licences.
